### PR TITLE
Weston: Enable DPMS

### DIFF
--- a/os/linux/iahwc.h
+++ b/os/linux/iahwc.h
@@ -19,6 +19,7 @@
 
 #include <gbm.h>
 #include <stdint.h>
+#include <hwcdefs.h>
 
 #define IAHWC_MODULE IAHWC_MODULE_INFO
 #define IAHWC_MODULE_STR "IAHWC_MODULE_INFO"
@@ -86,6 +87,7 @@ enum iahwc_function_descriptors {
   IAHWC_FUNC_DISPLAY_SET_GAMMA,
   IAHWC_FUNC_DISPLAY_SET_CONFIG,
   IAHWC_FUNC_DISPLAY_GET_CONFIG,
+  IAHWC_FUNC_DISPLAY_SET_POWER_MODE,
   IAHWC_FUNC_DISPLAY_CLEAR_ALL_LAYERS,
   IAHWC_FUNC_PRESENT_DISPLAY,
   IAHWC_FUNC_DISABLE_OVERLAY_USAGE,
@@ -163,6 +165,9 @@ typedef int (*IAHWC_PFN_DISPLAY_SET_CONFIG)(iahwc_device_t*,
 typedef int (*IAHWC_PFN_DISPLAY_GET_CONFIG)(iahwc_device_t*,
                                             iahwc_display_t display_handle,
                                             uint32_t* config);
+typedef int (*IAHWC_PFN_DISPLAY_SET_POWER_MODE)(iahwc_device_t*,
+                                                iahwc_display_t display_handle,
+                                                uint32_t power_mode);
 typedef int (*IAHWC_PFN_DISPLAY_CLEAR_ALL_LAYERS)(
     iahwc_device_t*, iahwc_display_t display_handle);
 typedef int (*IAHWC_PFN_PRESENT_DISPLAY)(iahwc_device_t*,

--- a/os/linux/linux_frontend.cpp
+++ b/os/linux/linux_frontend.cpp
@@ -147,6 +147,10 @@ iahwc_function_ptr_t IAHWC::HookGetFunctionPtr(iahwc_device_t* /* device */,
       return ToHook<IAHWC_PFN_DISPLAY_GET_CONFIGS>(
           DisplayHook<decltype(&IAHWCDisplay::GetDisplayConfigs),
                       &IAHWCDisplay::GetDisplayConfigs, uint32_t*, uint32_t*>);
+    case IAHWC_FUNC_DISPLAY_SET_POWER_MODE:
+      return ToHook<IAHWC_PFN_DISPLAY_SET_POWER_MODE>(
+          DisplayHook<decltype(&IAHWCDisplay::SetPowerMode),
+                      &IAHWCDisplay::SetPowerMode, uint32_t>);
     case IAHWC_FUNC_DISPLAY_SET_GAMMA:
       return ToHook<IAHWC_PFN_DISPLAY_SET_GAMMA>(
           DisplayHook<decltype(&IAHWCDisplay::SetDisplayGamma),
@@ -319,6 +323,12 @@ int IAHWC::IAHWCDisplay::GetDisplayConfigs(uint32_t* num_configs,
 
   if (!ret)
     return IAHWC_ERROR_NO_RESOURCES;
+
+  return IAHWC_ERROR_NONE;
+}
+
+int IAHWC::IAHWCDisplay::SetPowerMode(uint32_t power_mode) {
+  native_display_->SetPowerMode(power_mode);
 
   return IAHWC_ERROR_NONE;
 }

--- a/os/linux/linux_frontend.h
+++ b/os/linux/linux_frontend.h
@@ -86,6 +86,7 @@ class IAHWC : public iahwc_device {
     int SetDisplayGamma(float r, float b, float g);
     int SetDisplayConfig(uint32_t config);
     int GetDisplayConfig(uint32_t* config);
+    int SetPowerMode(uint32_t power_mode);
     int ClearAllLayers();
     int PresentDisplay(int32_t* release_fd);
     int RegisterVsyncCallback(iahwc_callback_data_t data,

--- a/os/linux/weston/plugin/compositor-iahwc.c
+++ b/os/linux/weston/plugin/compositor-iahwc.c
@@ -111,6 +111,7 @@ struct iahwc_backend {
   IAHWC_PFN_DISPLAY_SET_GAMMA iahwc_set_display_gamma;
   IAHWC_PFN_DISPLAY_SET_CONFIG iahwc_set_display_config;
   IAHWC_PFN_DISPLAY_GET_CONFIG iahwc_get_display_config;
+  IAHWC_PFN_DISPLAY_SET_POWER_MODE iahwc_display_set_power_mode;
   IAHWC_PFN_DISPLAY_CLEAR_ALL_LAYERS iahwc_display_clear_all_layers;
   IAHWC_PFN_PRESENT_DISPLAY iahwc_present_display;
   IAHWC_PFN_DISABLE_OVERLAY_USAGE iahwc_disable_overlay_usage;
@@ -201,6 +202,8 @@ struct iahwc_output {
   struct iahwc_spinlock spin_lock;
   struct timespec last_vsync_ts;
   uint32_t total_layers;
+
+  enum dpms_enum current_dpms;
 };
 
 static struct gl_renderer_interface *gl_renderer;
@@ -1028,6 +1031,37 @@ static int parse_gbm_format(const char *s, uint32_t default_value,
   return ret;
 }
 
+static void iahwc_set_dpms(struct weston_output *output_base,
+                           enum dpms_enum level) {
+  struct iahwc_output *output = to_iahwc_output(output_base);
+  struct iahwc_backend *b = to_iahwc_backend(output_base->compositor);
+  uint32_t power_level;
+
+  if (output->current_dpms == level)
+    return;
+
+  if (level == WESTON_DPMS_ON)
+    weston_output_schedule_repaint(output_base);
+
+  switch (level) {
+    case WESTON_DPMS_ON:
+      power_level = kOn;
+      break;
+    case WESTON_DPMS_STANDBY:
+      power_level = kDoze;
+      break;
+    case WESTON_DPMS_SUSPEND:
+      power_level = kDozeSuspend;
+      break;
+    case WESTON_DPMS_OFF:
+      power_level = kOff;
+      break;
+  }
+
+  b->iahwc_display_set_power_mode(b->iahwc_device, 0, power_level);
+  output->current_dpms = level;
+}
+
 /**
  * Choose suitable mode for an output
  *
@@ -1116,8 +1150,7 @@ static int iahwc_output_enable(struct weston_output *base) {
   output->base.repaint = iahwc_output_repaint;
   output->base.assign_planes = iahwc_assign_planes;
 
-  // XXX/TODO: No dpms for now.
-  output->base.set_dpms = NULL;
+  output->base.set_dpms = iahwc_set_dpms;
   output->base.switch_mode = iahwc_output_switch_mode;
 
   output->base.set_gamma = iahwc_output_set_gamma;
@@ -1142,6 +1175,8 @@ static int iahwc_output_enable(struct weston_output *base) {
   base->disable_planes = 0;
   unlock(&output->spin_lock);
 
+  output->current_dpms = WESTON_DPMS_ON;
+
   return 0;
 
 err:
@@ -1153,7 +1188,7 @@ static void iahwc_output_deinit(struct weston_output *base) {
   weston_plane_release(&output->overlay_plane);
   lock(&output->spin_lock);
   /* Force programming unused connectors and crtcs. */
-  output->state_invalid = true;
+                output->state_invalid = true;
   unlock(&output->spin_lock);
 }
 
@@ -1484,6 +1519,9 @@ static struct iahwc_backend *iahwc_backend_create(
   b->iahwc_get_display_config =
       (IAHWC_PFN_DISPLAY_GET_CONFIG)iahwc_device->getFunctionPtr(
           iahwc_device, IAHWC_FUNC_DISPLAY_GET_CONFIG);
+  b->iahwc_display_set_power_mode =
+      (IAHWC_PFN_DISPLAY_SET_POWER_MODE)iahwc_device->getFunctionPtr(
+          iahwc_device, IAHWC_FUNC_DISPLAY_SET_POWER_MODE);
   b->iahwc_display_clear_all_layers =
       (IAHWC_PFN_DISPLAY_CLEAR_ALL_LAYERS)iahwc_device->getFunctionPtr(
           iahwc_device, IAHWC_FUNC_DISPLAY_CLEAR_ALL_LAYERS);

--- a/public/hwcdefs.h
+++ b/public/hwcdefs.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
 #include <hwcrect.h>
 
 #include <unordered_map>
@@ -93,6 +94,7 @@ enum class DisplayType : int32_t {
   kMosaic = 4,
   kNested = 5
 };
+#endif //__cplusplus
 
 enum DisplayPowerMode {
   kOff = 0,         // Display is off
@@ -110,6 +112,7 @@ enum HWCColorTransform {
   kArbitraryMatrix = 1
 };
 
+#ifdef __cplusplus
 enum class HWCColorControl : int32_t {
   kColorHue = 0,
   kColorSaturation = 1,
@@ -159,4 +162,6 @@ using HWCColorMap =
     std::unordered_map<HWCColorControl, HWCColorProp, EnumClassHash>;
 
 }  // namespace hwcomposer
+#endif // __cplusplus
+
 #endif  // PUBLIC_HWCDEFS_H_


### PR DESCRIPTION
This patch adds code to enable dpms in the linux frontend and implements
the set_dpms hook in the iahwc backend.

Jira: None
Test: Display turns off after an idle period and is powered
      back on when input is received.

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>